### PR TITLE
Format battery voltage with NumberFormatter + " V"

### DIFF
--- a/MedtrumKitUI/ViewModels/Settings/PatchDetailsViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Settings/PatchDetailsViewModel.swift
@@ -23,12 +23,14 @@ class PatchDetailsViewModel: PatchLifetimeFormatting, ObservableObject {
         return formatter
     }()
 
-    //let batteryFormatter: QuantityFormatter = {
-    //    let formatter = QuantityFormatter(for: .volt())
-    //    formatter.numberFormatter.minimumFractionDigits = 2
-    //    formatter.numberFormatter.maximumFractionDigits = 2
-    //    return formatter
-    //}()
+    // LoopUnit has no `.volt` case, so volts are rendered via NumberFormatter + " V".
+    let batteryFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter
+    }()
 
     let dateTimeFormatter = {
         let formatter = DateFormatter()
@@ -61,8 +63,8 @@ class PatchDetailsViewModel: PatchLifetimeFormatting, ObservableObject {
     }
 
     func batteryText(for voltage: Double) -> String {
-        let quantity = voltage
-        return String(format: "%0.2f", quantity)
+        guard let formatted = batteryFormatter.string(from: NSNumber(value: voltage)) else { return "" }
+        return "\(formatted) V"
     }
 
     func reservoirText(for units: Double) -> String {

--- a/MedtrumKitUI/ViewModels/Settings/PreviousPatchDetailsViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Settings/PreviousPatchDetailsViewModel.swift
@@ -21,12 +21,14 @@ class PreviousPatchDetailsViewModel: PatchLifetimeFormatting, ObservableObject {
         return formatter
     }()
 
-    //let batteryFormatter: QuantityFormatter = {
-    //    let formatter = QuantityFormatter(for: .volt())
-    //    formatter.numberFormatter.minimumFractionDigits = 2
-    //    formatter.numberFormatter.maximumFractionDigits = 2
-    //    return formatter
-    //}()
+    // LoopUnit has no `.volt` case, so volts are rendered via NumberFormatter + " V".
+    let batteryFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter
+    }()
 
     let dateTimeFormatter = {
         let formatter = DateFormatter()
@@ -58,10 +60,10 @@ class PreviousPatchDetailsViewModel: PatchLifetimeFormatting, ObservableObject {
         pumpManager?.removeStatusObserver(self)
     }
 
-    //func batteryText(for voltage: Double) -> String {
-    //    let quantity = LoopQuantity(unit: .volt, doubleValue: voltage)
-    //    return batteryFormatter.string(from: quantity) ?? ""
-    //}
+    func batteryText(for voltage: Double) -> String {
+        guard let formatted = batteryFormatter.string(from: NSNumber(value: voltage)) else { return "" }
+        return "\(formatted) V"
+    }
 
     func reservoirText(for units: Double) -> String {
         let quantity = LoopQuantity(unit: .internationalUnit, doubleValue: units)

--- a/MedtrumKitUI/Views/Settings/PreviousPatchDetailsView.swift
+++ b/MedtrumKitUI/Views/Settings/PreviousPatchDetailsView.swift
@@ -28,7 +28,7 @@ struct PreviousPatchDetailsView: View {
                 )
                 sectionItem(
                     title: Text("Battery", comment: "Text for battery voltageB"),
-                    value: String(format: "%0.2f", viewModel.battery)
+                    value: viewModel.batteryText(for: viewModel.battery)
                 )
 
                 if let reservoirLevel = viewModel.reservoirLevel,


### PR DESCRIPTION
## Summary
Replace the temporary `String(format: "%0.2f", voltage)` placeholder for battery voltage display with a `NumberFormatter` + ` V` suffix.

LoopUnit currently has no `.volt` case, so `QuantityFormatter` can't render volts. A locale-aware `NumberFormatter` restores the previous UX (2 fraction digits, decimal style with locale-correct separators) without depending on a unit type we don't have.

Applies to both `PatchDetailsViewModel` and `PreviousPatchDetailsViewModel`, and switches `PreviousPatchDetailsView` back to calling the view model's `batteryText(for:)` helper.

## Test plan
- [ ] Active patch settings: Battery voltage row shows `4.10 V` (or similar) with locale-correct decimal separator
- [ ] Previous patch detail: same formatting
- [ ] No `String(format:)` printf for displayed values